### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0](https://github.com/COMBINE-lab/kde-rs/releases/tag/v0.1.0) - 2024-07-29
 
 ### Added
+- actions
+- update cargo toml
+
+### Other
+- release
+- make fields public
+- Add example to documentation
+- Change function name
+- Add ability to do interpolation for query (but not yet sufficiently tested)
+- Change name of evaluate_kde and of KDEModel struct
+- More docs, more params to alternative constructor
+- Docs
+- Start adding basic documentation
+- Update readme
+- add code of conduct and contributing
+- split example only deps into dev dependencies
+- rearrange as proper library with prior main as an example
+- make it even more like the python version
+- make it even more like the python version
+- clean compile
+- allow passing in bandwidth
+- getting close to python
+- trying stuff out
+- working on interface
+- working on new interface
+- initial kde function
+- Initial commit
+
+## [0.1.0](https://github.com/COMBINE-lab/kde-rs/releases/tag/v0.1.0) - 2024-07-29
+
+### Added
 - update cargo toml
 
 ### Other


### PR DESCRIPTION
## 🤖 New release
* `kders`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).